### PR TITLE
fixup/key_scanner: shorten delay for `read_matrix`

### DIFF
--- a/src/key_scanner.rs
+++ b/src/key_scanner.rs
@@ -374,7 +374,7 @@ impl KeyScanner {
             let mut hot_pins = RowState::new();
             for (j, col) in self.matrix_pins.cols.iter().enumerate() {
                 // add a slight delay to allow for stable read of the input pin
-                small_delay(768);
+                small_delay(512);
                 // if the column pin is low, the key was pressed
                 if col.is_low() {
                     hot_pins.set_column(j, true);


### PR DESCRIPTION
Shortens the delay in the inner loop of the key scanner to improve responsiveness without spamming repeated keys.

Setting the delay too low results in many repeated keys being registered on a single key press. Setting the value too high makes the keyboard feel sticky and unresponsive.

The current middle value seems to be a nice balance. There may end up being a cleaner solution for slowing down the processor here, but this works for now.